### PR TITLE
fix: Support latest changes with deprecated erl_interface - fix {:error, :bad_name} error

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -18,7 +18,7 @@ defmodule Mix.Tasks.Compile.StemexSnowball do
     else
       Mix.Shell.IO.error("""
         Missing snowball compiler on your path
-        install it for instance doing : 
+        install it for instance doing :
           wget http://snowball.tartarus.org/dist/snowball_code.tgz
           tar xvzf snowball_code.tgz
           cd snowball_code
@@ -44,9 +44,9 @@ defmodule Mix.Tasks.Compile.StemexNif do
   end
 
   defp cc_args do
-    [i_erts]=Path.wildcard("#{:code.root_dir}/erts*/include")
-    i_ei=:code.lib_dir(:erl_interface,:include)
-    l_ei=:code.lib_dir(:erl_interface,:lib)
+    [i_erts] = Path.wildcard("#{:code.root_dir}/erts*/include")
+    [i_ei] = Path.wildcard("#{:code.root_dir}/lib/erl_interface*/include")
+    [l_ei] = Path.wildcard("#{:code.root_dir}/lib/erl_interface*/lib")
     args = ["-L#{l_ei}","-lei","-I#{i_ei}","-I#{i_erts}","-Wall","-shared","-fPIC"] #,"-v"]
     args ++ if {:unix,:darwin}==:os.type, do: ["-undefined","dynamic_lookup","-dynamiclib"], else: []
   end
@@ -73,8 +73,8 @@ defmodule Stemex.Mixfile do
        }
      ],
      description: """
-       Stemex is a NIF wrapper above snowball containing stemmers for : 
-       danish, dutch, english, finnish, french, german, hungarian, italian, kraaij_pohlmann, 
+       Stemex is a NIF wrapper above snowball containing stemmers for :
+       danish, dutch, english, finnish, french, german, hungarian, italian, kraaij_pohlmann,
        lovins, norwegian, portuguese, romanian, russian, spanish, swedish, turkish.
      """,
      deps: []]
@@ -84,6 +84,6 @@ defmodule Stemex.Mixfile do
     [applications: []]
   end
 
-  defp compilers(:dev), do: [:stemex_snowball] ++ compilers(:all) 
+  defp compilers(:dev), do: [:stemex_snowball] ++ compilers(:all)
   defp compilers(_), do: [:stemex_nif] ++ Mix.compilers
 end


### PR DESCRIPTION
We wanted to use latest Elixir version but Stemex dependency have issues with `{:error, :bad_name}`
```
==> stemex
could not compile dependency :stemex, "mix compile" failed. Errors may have been logged above. You can recompile this dependency with "mix deps.compile stemex --force", update it with "mix deps.update stemex" or clean it with "mix deps.clean stemex"
** (Protocol.UndefinedError) protocol String.Chars not implemented for {:error, :bad_name} of type Tuple
    (elixir 1.15.6) lib/string/chars.ex:3: String.Chars.impl_for!/1
    (elixir 1.15.6) lib/string/chars.ex:22: String.Chars.to_string/1
    /<ANONYMIZED>/deps/stemex/mix.exs:50: Mix.Tasks.Compile.StemexNif.cc_args/0
    /<ANONYMIZED>/deps/stemex/mix.exs:41: Mix.Tasks.Compile.StemexNif.run/1
    (mix 1.15.6) lib/mix/task.ex:447: anonymous fn/3 in Mix.Task.run_task/5
    (mix 1.15.6) lib/mix/tasks/compile.all.ex:124: Mix.Tasks.Compile.All.run_compiler/2
    (mix 1.15.6) lib/mix/tasks/compile.all.ex:104: Mix.Tasks.Compile.All.compile/4
    (mix 1.15.6) lib/mix/tasks/compile.all.ex:93: Mix.Tasks.Compile.All.with_logger_app/2
```

My idea was related to changes in OTP:

```
OTP-16328

Application(s):
erl_interface

As announced in OTP 22.0, the deprecated parts of erl_interface have now been removed (essentially all C functions with prefix erl_).
```
Source: [OTP-23](https://www.erlang.org/patches/otp-23.0)

Changed code to use `Path.wildcard/1` instead of `:code.lib_dir/2`